### PR TITLE
Don't to invoke default form helper on typeless elements (e.g. Captcha)

### DIFF
--- a/src/Zucchi/Form/View/Helper/FormElement.php
+++ b/src/Zucchi/Form/View/Helper/FormElement.php
@@ -32,11 +32,13 @@ class FormElement extends ZendFormElement
 
         $type = $element->getAttribute('type');
 
-        $pm = $renderer->getHelperPluginManager();
+        if (!empty($type)) {
+            $pm = $renderer->getHelperPluginManager();
 
-        if ($pm->has('form_' . $type)) {
-            $helper = $pm->get('form_' . $type);
-            return $helper($element);
+            if ($pm->has('form_' . $type)) {
+                $helper = $pm->get('form_' . $type);
+                return $helper($element);
+            }
         }
 
         return parent::render($element);


### PR DESCRIPTION
If the type of the form renderer cannot be optained, the render method
of the form element helper reached for the 'form_' helper and passed an
element to it that caused an exception. Instead, the parent render
method should be called.
